### PR TITLE
Normalize markdown front matter and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Glitch Registry
 
-Открытый реестр глитчей реальности: интерактивные сцены и карточки.
+Открытый реестр глитчей реальности: интерактивные сцены и карточки. Список глитчей берётся из `content/glitches.json`.
 
 ## Структура
 
@@ -9,25 +9,12 @@
 - `legacy/` — архив старых страниц
 - `assets/` — статические ресурсы
 
-## Сцены
+## Безопасность
 
-- [observer-problem](scenes/glitch-observer-problem.html)
-- [nonlocality](scenes/glitch-nonlocality.html)
-- [quantum-tunneling](scenes/glitch-quantum-tunneling.html)
-- [invisible-universe](scenes/glitch-invisible-universe.html)
-- [consciousness-problem](scenes/glitch-consciousness-problem.html)
-- [quantum-teleportation](scenes/glitch-quantum-teleportation.html)
-- [fine-tuning](scenes/glitch-fine-tuning.html)
-- [quantum-superposition](scenes/glitch-quantum-superposition.html)
-- [belief-power](scenes/glitch-belief-power.html)
-- [quantum-decoherence](scenes/glitch-quantum-decoherence.html)
-- [arrow-of-time](scenes/glitch-arrow-of-time.html)
-- [quantum-entanglement](scenes/glitch-quantum-entanglement.html)
-- [cosmic-loneliness](scenes/glitch-cosmic-loneliness.html)
-- [dark-matter-visualization](scenes/glitch-dark-matter-visualization.html)
-- [entanglement-visualization](scenes/glitch-entanglement-visualization.html)
-
-Старые версии страниц находятся в каталоге `legacy/`.
+- Статический проект, без серверной части и сбора данных.
+- Markdown рендерится через `marked` + `DOMPurify` и очищается от небезопасного HTML.
+- Прогресс прохождения сохраняется локально в `localStorage`.
+- Нет аналитики, трекеров и сторонних сетевых запросов.
 
 ## Запуск
 

--- a/assets/js/md.js
+++ b/assets/js/md.js
@@ -16,6 +16,9 @@
 
   window.renderMarkdown = async function (markdown, target) {
     await ready;
+    if (markdown.startsWith('---')) {
+      markdown = markdown.replace(/^---[\s\S]*?\n---\n?/, '');
+    }
     var html = marked.parse(markdown);
     var safe = DOMPurify.sanitize(html);
     target.innerHTML = safe;

--- a/content/glitches/anthropic-principle.md
+++ b/content/glitches/anthropic-principle.md
@@ -1,8 +1,10 @@
+---
 id: glitch-anthropic
 title: Антропный принцип
-layer: Наблюдатель
+category: Наблюдатель
 tags: [отбор наблюдателя, селекция]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/bekenstein-bound.md
+++ b/content/glitches/bekenstein-bound.md
@@ -1,8 +1,10 @@
+---
 id: glitch-bekenstein-bound
 title: Предел Бекенштейна
-layer: Информация
+category: Информация
 tags: [инфо-ёмкость, площадь, гравитация]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/big-crunch-rip.md
+++ b/content/glitches/big-crunch-rip.md
@@ -1,8 +1,10 @@
+---
 id: glitch-big-crunch-rip
 title: Большое сжатие / Большой разрыв
-layer: Космос
+category: Космос
 tags: [судьба вселенной, геометрия]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/block-universe.md
+++ b/content/glitches/block-universe.md
@@ -1,8 +1,10 @@
+---
 id: glitch-block-universe
 title: Блок-вселенная (вечное настоящее)
-layer: Время
+category: Время
 tags: [4D, детерминизм, опыт времени]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/chinese-room.md
+++ b/content/glitches/chinese-room.md
@@ -1,8 +1,10 @@
+---
 id: glitch-chinese-room
 title: Китайская комната (Сёрл)
-layer: Идентичность
+category: Идентичность
 tags: [понимание, символы, ИИ]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/collapse-problem.md
+++ b/content/glitches/collapse-problem.md
@@ -1,8 +1,10 @@
+---
 id: glitch-collapse-problem
 title: Проблема коллапса
-layer: Квант
+category: Квант
 tags: [интерпретации, измерение]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/delayed-choice.md
+++ b/content/glitches/delayed-choice.md
@@ -1,8 +1,10 @@
+---
 id: glitch-delayed-choice
 title: Задержанный выбор (Уилер)
-layer: Квант
+category: Квант
 tags: [измерение, интерференция, причинность]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/godel-incompleteness.md
+++ b/content/glitches/godel-incompleteness.md
@@ -1,8 +1,10 @@
+---
 id: glitch-godel
 title: Неполнота Гёделя
-layer: Логика
+category: Логика
 tags: [формальные системы, доказуемость]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/goodhart-law.md
+++ b/content/glitches/goodhart-law.md
@@ -1,8 +1,10 @@
+---
 id: glitch-goodhart
 title: Закон Гудхарта
-layer: Информация
+category: Информация
 tags: [метрика, оптимизация, цель]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/heat-death.md
+++ b/content/glitches/heat-death.md
@@ -1,8 +1,10 @@
+---
 id: glitch-heat-death
 title: Тепловая смерть вселенной
-layer: Космос
+category: Космос
 tags: [энтропия, равновесие, конец]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/landauer-principle.md
+++ b/content/glitches/landauer-principle.md
@@ -1,8 +1,10 @@
+---
 id: glitch-landauer
 title: Принцип Ландауэра
-layer: Информация
+category: Информация
 tags: [бит, тепло, вычисления]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/liar-paradox.md
+++ b/content/glitches/liar-paradox.md
@@ -1,8 +1,10 @@
+---
 id: glitch-liar
 title: Парадокс лжеца
-layer: Логика
+category: Логика
 tags: [самоссылка, истина, логика]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/map-vs-territory.md
+++ b/content/glitches/map-vs-territory.md
@@ -1,8 +1,10 @@
+---
 id: glitch-map-territory
 title: Карта и территория
-layer: Информация
+category: Информация
 tags: [модель, реальность, редукция]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/mind-uploading.md
+++ b/content/glitches/mind-uploading.md
@@ -1,8 +1,10 @@
+---
 id: glitch-mind-uploading
 title: Загрузка разума / копирование личности
-layer: Идентичность
+category: Идентичность
 tags: [копия, оригинал, телепортация]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/multiverse-inflation.md
+++ b/content/glitches/multiverse-inflation.md
@@ -1,8 +1,10 @@
+---
 id: glitch-multiverse-inflation
 title: Инфляция и мультивселенные
-layer: Космос
+category: Космос
 tags: [инфляция, пузыри, ансамбль]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/quantum-darwinism.md
+++ b/content/glitches/quantum-darwinism.md
@@ -1,8 +1,10 @@
+---
 id: glitch-quantum-darwinism
 title: Квантовый дарвинизм
-layer: Квант
+category: Квант
 tags: [среда, декогеренция, избираемость]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/quantum-zeno.md
+++ b/content/glitches/quantum-zeno.md
@@ -1,8 +1,10 @@
+---
 id: glitch-quantum-zeno
 title: Квантовый парадокс Зенона
-layer: Квант
+category: Квант
 tags: [измерение, динамика, заморозка]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/retrocausality.md
+++ b/content/glitches/retrocausality.md
@@ -1,8 +1,10 @@
+---
 id: glitch-retrocausality
 title: Ретро-причинность
-layer: Время
+category: Время
 tags: [причинность, будущее→прошлое]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/ship-of-theseus.md
+++ b/content/glitches/ship-of-theseus.md
@@ -1,8 +1,10 @@
+---
 id: glitch-ship-of-theseus
 title: Корабль Тесея
-layer: Идентичность
+category: Идентичность
 tags: [личность, замена, тождество]
 status: draft
+---
 
 ### TL;DR
 

--- a/content/glitches/zeno-paradoxes.md
+++ b/content/glitches/zeno-paradoxes.md
@@ -1,8 +1,10 @@
+---
 id: glitch-zeno
 title: Парадоксы Зенона
-layer: Логика
+category: Логика
 tags: [непрерывность, бесконечность, движение]
 status: draft
+---
 
 ### TL;DR
 


### PR DESCRIPTION
## Summary
- normalize YAML front matter across glitch cards
- strip front matter from Markdown renderer
- clean up README and add security notes

## Testing
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689605edf8c4832186646cd998150f7d