### PR TITLE
feat: mobile sidebar burger and sticky headers

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -13,6 +13,29 @@
     'Логика': 'logic',
     'Наблюдатель': 'observer'
   };
+  var sidebar = document.querySelector('.sidebar');
+  var sidebarToggle = document.getElementById('sidebar-toggle');
+  var sidebarOverlay = document.getElementById('sidebar-overlay');
+
+  function openSidebar() {
+    if (sidebar) sidebar.classList.add('open');
+    if (sidebarOverlay) sidebarOverlay.classList.add('show');
+  }
+
+  function closeSidebar() {
+    if (sidebar) sidebar.classList.remove('open');
+    if (sidebarOverlay) sidebarOverlay.classList.remove('show');
+  }
+
+  if (sidebarToggle) {
+    sidebarToggle.addEventListener('click', openSidebar);
+  }
+  if (sidebarOverlay) {
+    sidebarOverlay.addEventListener('click', closeSidebar);
+  }
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') closeSidebar();
+  });
 
   function getManifest() {
     if (!manifestPromise) {
@@ -282,7 +305,10 @@
     updateHashQuery();
   });
 
-  window.addEventListener('hashchange', load);
+  window.addEventListener('hashchange', function () {
+    closeSidebar();
+    load();
+  });
   window.addEventListener('DOMContentLoaded', function () {
     if (!location.hash) {
       location.hash = '#/overview';

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <nav>
+  <button id="sidebar-toggle" aria-controls="sidebar">☰ Реестр</button>
   <a href="#/glitch/observer-problem">Реестр</a>
   <a href="#/scene/observer-problem">Сцены</a>
   <a href="#/overview">Обзор</a>
@@ -29,6 +30,7 @@
   </aside>
   <div id="content" class="content"></div>
 </div>
+<div id="sidebar-overlay"></div>
 <script src="assets/js/lexicon.js"></script>
 <script src="assets/js/md.js"></script>
 <script src="assets/js/progress.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -737,6 +737,9 @@ nav {
   background: #111;
   color: #eee;
   padding: 10px;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 nav a {
   color: #0f0;
@@ -776,6 +779,9 @@ button, input, select {
   box-shadow: 0 1px 2.5px rgba(0,0,0,0.3);
 }
 
+#sidebar-toggle{display:none;background:none;border:none;color:#0f0;font-size:16px;margin-right:1rem}
+#sidebar-overlay{display:none}
+
 /* Hub layout */
 .hub { display:flex; gap:16px; max-width:1080px; margin:0 auto; padding:16px; }
 .sidebar { width:280px; max-height:calc(100vh - 90px); overflow:auto; position:sticky; top:60px; }
@@ -798,6 +804,7 @@ button, input, select {
 .scene-head{max-width:1080px;margin:0 auto 10px;padding:10px 20px 0;display:flex;align-items:center;gap:12px;justify-content:space-between}
 .scene-head h1{margin:6px 0 8px;font-size:clamp(22px,2.6vw,30px)}
 .scene-frame{max-width:1080px;margin:0 auto;padding:0 20px}
+.card-head,.scene-head{position:sticky;top:0;background:#111;z-index:10}
 .cat { display:inline-block; padding:2px 8px; border:1px solid rgba(255,255,255,.15); border-radius:8px; font-size:12px; opacity:.85; }
 .cat-quant{border-color:#56e0ff80}
 .cat-time{border-color:#ffd58080}
@@ -840,4 +847,13 @@ button, input, select {
 @media (max-width: 900px) {
   .hub { flex-direction:column; }
   .sidebar { position:static; max-height:none; width:100%; }
+}
+
+@media (max-width: 768px) {
+  nav a:first-child { display:none; }
+  #sidebar-toggle { display:inline-block; }
+  .sidebar { display:none; position:fixed; top:0; left:0; height:100vh; width:80%; max-width:300px; background:#111; padding:16px; box-shadow:2px 0 8px rgba(0,0,0,.5); z-index:1001; overflow:auto; }
+  .sidebar.open { display:block; }
+  #sidebar-overlay { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,.6); z-index:1000; display:none; }
+  #sidebar-overlay.show { display:block; }
 }


### PR DESCRIPTION
## Summary
- add header burger button with overlay sidebar for mobile
- make nav, card and scene headers sticky
- wire sidebar toggle handlers for tap, outside click, and ESC

## Testing
- `npm run lint:html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896331c5b288321b8cc8efa20b646b6