### PR TITLE
Scene cleanup v1.1: hide legacy scene chrome

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -251,7 +251,22 @@
               + '<div class="actions-right"><button class="btn-link" data-share>Поделиться</button></div>'
               + '</div>'
               + '<div class="scene-frame"></div>';
-            contentEl.querySelector('.scene-frame').innerHTML = html;
+            var frame = contentEl.querySelector('.scene-frame');
+            frame.innerHTML = html;
+            [
+              '.series',
+              '.series-bar',
+              '[data-series]',
+              '.bug-title',
+              '.bug-header',
+              'h1.bug',
+              '.bug-number',
+              '.progress',
+              '.progress-bar',
+              '.promise-section'
+            ].forEach(function (sel) {
+              frame.querySelectorAll(sel).forEach(function (el) { el.remove(); });
+            });
             if (typeof window.__initScene === 'function') { window.__initScene(); }
             if (typeof window.__applyParams === 'function') { window.__applyParams(params); }
           } catch (e) {

--- a/styles.css
+++ b/styles.css
@@ -832,15 +832,17 @@ button, input, select {
 .scene-frame .series,
 .scene-frame .series-header,
 .scene-frame .series-title,
+.scene-frame .series-bar,
 .scene-frame [data-series],
 .scene-frame .bug-title,
-.scene-frame .bug-number,
+.scene-frame .bug-header,
 .scene-frame h1.bug,
-.scene-frame .legacy-bug,
+.scene-frame .bug-number,
 .scene-frame .progress,
 .scene-frame .progress-bar,
 .scene-frame .progress-fill,
-.scene-frame .bug-header,
+.scene-frame .promise-section,
+.scene-frame .legacy-bug,
 .scene-frame .next-bug { display:none !important; }
 
 /* Mobile adaptation */


### PR DESCRIPTION
## Summary
- strip legacy series, bug and progress elements after loading scene HTML
- hide leftover legacy selectors and ensure sticky `.scene-head`

## Testing
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896365f6cc88321b3a54eeca21b8031