### PR TITLE
feat: enhance landing controls

### DIFF
--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -6,6 +6,7 @@
   var tagEl = document.getElementById('landing-tagline');
   var enterBtn = document.getElementById('enter-btn');
   var muteBtn = document.getElementById('mute-btn');
+  var skipBtn = document.getElementById('skip-btn');
   var skipCb = document.getElementById('skip-checkbox');
   var canvas = document.getElementById('fallback');
   var audio;
@@ -135,6 +136,7 @@
 
   muteBtn.addEventListener('click', toggleMute);
   enterBtn.addEventListener('click', enter);
+  skipBtn.addEventListener('click', enter);
   skipCb.addEventListener('change', function () {
     if (skipCb.checked) {
       localStorage.setItem('landing.skip', '1');

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <script>
     (function () {
       var params = new URLSearchParams(location.search);
-      if (!params.has('hub')) {
+      if (params.get('hub') !== '1') {
         try {
           var skip = localStorage.getItem('landing.skip') === '1';
           var last = parseInt(localStorage.getItem('landing.lastSeenAt'), 10) || 0;

--- a/landing.html
+++ b/landing.html
@@ -19,7 +19,8 @@
     </div>
     <div class="controls">
       <button id="mute-btn" tabindex="0" aria-label="Переключить звук">Mute</button>
-      <label tabindex="0"><input type="checkbox" id="skip-checkbox" tabindex="0" aria-label="Всегда пропускать"> Skip intro</label>
+      <button id="skip-btn" tabindex="0" aria-label="Пропустить интро">Skip intro</button>
+      <label tabindex="0" for="skip-checkbox" aria-label="Всегда пропускать"><input type="checkbox" id="skip-checkbox" tabindex="0" aria-label="Всегда пропускать"> Всегда пропускать</label>
     </div>
     <footer>
       <small>Звук включится после клика. <a href="about.html" tabindex="0" aria-label="Об архиве">Об архиве</a></small>


### PR DESCRIPTION
## Summary
- add skip-intro button and persistent "always skip" option on landing page
- wire skip control into landing script and redirect logic
- refine hub redirect to honor `?hub=1`

## Testing
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689650712ce483219c20ee34ddfa4a28