### PR TITLE
fix: clean legacy banners and overview polish

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -243,6 +243,19 @@
           body.className = 'md-body';
           contentEl.appendChild(body);
           await window.renderMarkdown(md, body);
+          body.querySelectorAll('.hero,.legacy,.btns,.bug-series,.series-banner,.project-banner')
+            .forEach(function (n) { n.remove(); });
+          var first = body.querySelector('h3');
+          if (first) {
+            var txt = (first.textContent || '').trim().toLowerCase();
+            var legacyH = ['глюки', 'визуализации', 'о проекте'];
+            if (legacyH.some(function (t) { return txt.includes(t); })) {
+              while (body.firstChild && body.firstChild !== first) {
+                body.removeChild(body.firstChild);
+              }
+              first.remove();
+            }
+          }
 
           var headings = body.querySelectorAll('h3');
           if (headings.length) {
@@ -406,7 +419,7 @@
             cont.className = 'tile continue';
             var contBtn = document.createElement('button');
             contBtn.className = 'btn-link btn-primary';
-            contBtn.textContent = 'Вернуться к ' + lastItem.title;
+            contBtn.textContent = 'Продолжить → ' + lastItem.title;
             contBtn.addEventListener('click', function () {
               location.hash = '#/' + last.type + '/' + last.slug;
             });

--- a/styles.css
+++ b/styles.css
@@ -790,7 +790,7 @@ button, input, select {
 /* Sidebar */
 .gl-item { display:flex; align-items:center; gap:8px; padding:6px 8px; border-radius:8px; text-decoration:none; }
 .gl-item:hover { background:rgba(255,255,255,.05); }
-.gl-item.active { background:rgba(255,255,255,.06); border-radius:8px; }
+.gl-item.active { background:rgba(255,255,255,.08); border-radius:8px; }
 .gl-item .check { margin-left:auto; opacity:.85; }
 .badge { font-size:11px; padding:1px 6px; border:1px solid rgba(255,255,255,.15); border-radius:999px; opacity:.85; }
 .badge.scene { border-color:#57ffae44; }
@@ -815,7 +815,7 @@ button, input, select {
 .cat-observer{border-color:#b0ffc680}
 
 .md-body { max-width:820px; margin:0 auto; padding:16px 20px; line-height:1.65; }
-.md-body h2, .md-body h3 { margin:1.2em 0 .4em; font-size:clamp(18px,2vw,22px); }
+.md-body h2, .md-body h3 { margin:1.2em 0 .4em; font-size:clamp(18px,2vw,22px); scroll-margin-top:80px; }
 .lex{border-bottom:1px dotted rgba(255,255,255,.4);cursor:help}
 .lex:hover{opacity:.9}
 
@@ -836,7 +836,7 @@ button, input, select {
 .tile.continue { grid-column:1/-1; text-align:center; }
 .tile button { margin-top:8px; }
 
-.toast { position:fixed; bottom:20px; right:20px; background:rgba(0,0,0,.8); padding:8px 14px; border-radius:8px; opacity:0; transition:opacity .3s; }
+.toast { position:fixed; bottom:20px; right:20px; background:rgba(0,0,0,.8); padding:8px 14px; border-radius:8px; opacity:0; transition:opacity .3s; z-index:20; }
 .toast.show { opacity:1; }
 
 .callout { border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:16px 18px; margin:16px 0; background:rgba(255,255,255,.03); }


### PR DESCRIPTION
## Summary
- strip legacy banners and preface blocks from card markdown
- show "Продолжить" tile and progress counts on overview with higher contrast
- tweak UI spacing and z-index for better scrolling and toast visibility

## Testing
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896546b1fe88321a86781458dd5cffd