### PR TITLE
feat: enhance sidebar keyboard search

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -790,7 +790,7 @@ button, input, select {
 /* Sidebar */
 .gl-item { display:flex; align-items:center; gap:8px; padding:6px 8px; border-radius:8px; text-decoration:none; }
 .gl-item:hover { background:rgba(255,255,255,.05); }
-.gl-item.active { background:rgba(255,255,255,.08); border-radius:8px; }
+.gl-item.active, .gl-item.focused { background:rgba(255,255,255,.08); border-radius:8px; }
 .gl-item .check { margin-left:auto; opacity:.85; }
 .badge { font-size:11px; padding:1px 6px; border:1px solid rgba(255,255,255,.15); border-radius:999px; opacity:.85; }
 .badge.scene { border-color:#57ffae44; }


### PR DESCRIPTION
## Summary
- add keyboard navigation with Home/End, Esc clear and search focus hotkeys
- highlight search matches with <mark> and keep selection visible
- style sidebar focus state

## Testing
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896595136b8832199b6e436807b969f