### PR TITLE
Add procedural intro overlay with audio and preferences

### DIFF
--- a/assets/js/intro.js
+++ b/assets/js/intro.js
@@ -1,0 +1,108 @@
+(() => {
+  const LS = {
+    get k() { return { skip:'intro:alwaysSkip', seen:'intro:lastSeen', muted:'intro:muted' } }
+  };
+  let ctx, audio, started=false, muted=false, rafId;
+
+  function initAudio(){
+    if (audio) return;
+    try {
+      const AC = window.AudioContext||window.webkitAudioContext;
+      audio = new AC();
+      const o1 = audio.createOscillator(), o2 = audio.createOscillator();
+      const g1 = audio.createGain(), g2 = audio.createGain();
+      const filt = audio.createBiquadFilter();
+      const fb = audio.createDelay(); const fbGain = audio.createGain();
+      o1.type='sine'; o2.type='triangle';
+      o1.frequency.value=110; o2.frequency.value=220;
+      g1.gain.value=g2.gain.value=0.03;
+      filt.type='lowpass'; filt.frequency.value=1200;
+      fb.delayTime.value=0.25; fbGain.gain.value=0.2;
+
+      o1.connect(g1).connect(filt);
+      o2.connect(g2).connect(filt);
+      filt.connect(audio.destination);
+      filt.connect(fb).connect(fbGain).connect(filt);
+
+      o1.start(); o2.start();
+    } catch {}
+  }
+
+  function draw(ts){
+    const c=document.getElementById('intro-canvas');
+    if(!c) return;
+    if(!ctx){ c.width=innerWidth; c.height=innerHeight; ctx=c.getContext('2d'); }
+    const w=c.width=innerWidth, h=c.height=innerHeight;
+    ctx.fillStyle='rgba(0,0,0,0.3)'; ctx.fillRect(0,0,w,h);
+    for(let i=0;i<180;i++){
+      const x=(Math.sin(i*13.37+ts*0.0007)+1)/2*w;
+      const y=(Math.cos(i*9.91 +ts*0.0004)+1)/2*h;
+      const r=(Math.sin(i+ts*0.002)+1)*1.2+0.3;
+      ctx.fillStyle=`hsl(${(i*7+ts*0.02)%360} 80% 60% / .6)`;
+      ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+    }
+    rafId=requestAnimationFrame(draw);
+  }
+
+  function prefetch(){
+    const s1=document.createElement('link');
+    s1.rel='prefetch'; s1.href='assets/js/router.js';
+    document.head.appendChild(s1);
+    const s2=document.createElement('link');
+    s2.rel='prefetch'; s2.href='content/glitches.json';
+    document.head.appendChild(s2);
+  }
+
+  function show(force=false){
+    const seen=+localStorage.getItem(LS.k.seen)||0;
+    const skip=localStorage.getItem(LS.k.skip)==='1';
+    const week=7*24*3600*1000;
+    if (!force && skip && Date.now()-seen<week){
+      location.hash = location.hash || '#/overview';
+      return;
+    }
+    document.getElementById('intro')?.removeAttribute('hidden');
+    requestAnimationFrame(draw);
+    requestIdleCallback?.(prefetch);
+  }
+
+  function hideToHub(){
+    localStorage.setItem(LS.k.seen, Date.now().toString());
+    cancelAnimationFrame(rafId);
+    document.getElementById('intro')?.setAttribute('hidden','');
+    location.hash='#/overview';
+  }
+
+  function bind(){
+    const enter=document.getElementById('intro-enter');
+    const skip=document.getElementById('intro-skip');
+    const always=document.getElementById('intro-always-skip');
+    const mute=document.getElementById('intro-mute');
+
+    const gesture=()=>{ if(!started){ initAudio(); started=true; } };
+    ['click','pointerdown','keydown','touchstart'].forEach(ev=>{
+      document.addEventListener(ev,gesture,{once:true,passive:true});
+    });
+
+    enter?.addEventListener('click', hideToHub);
+    skip?.addEventListener('click', hideToHub);
+    always?.addEventListener('change', e=>{
+      localStorage.setItem(LS.k.skip, e.target.checked?'1':'');
+      hideToHub();
+    });
+    mute?.addEventListener('click', ()=>{
+      muted=!muted; localStorage.setItem(LS.k.muted, muted?'1':'');
+      mute.toggleAttribute('data-muted', muted);
+      if (audio) (muted? audio.suspend(): audio.resume()).catch(()=>{});
+    });
+
+    if (localStorage.getItem(LS.k.muted)==='1') mute?.setAttribute('data-muted','');
+  }
+
+  window.intro = { show, hideToHub };
+  window.addEventListener('DOMContentLoaded', ()=>{
+    bind();
+    const url=new URL(location.href);
+    if (url.searchParams.get('skip')==='0') show(true); else show(false);
+  });
+})();

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -423,7 +423,6 @@
     saveScroll(lastSlug);
     closeSidebar();
     if (!location.hash) {
-      location.hash = '#/overview';
       return;
     }
     var rawHash = location.hash.slice(1);

--- a/index.html
+++ b/index.html
@@ -5,27 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Glitch Registry</title>
   <link rel="stylesheet" href="styles.css">
-  <script>
-    (function () {
-      var params = new URLSearchParams(location.search);
-      if (params.get('hub') === '1') return;
-      if (params.get('skip') === '0') {
-        location.href = 'landing.html';
-        return;
-      }
-      try {
-        var skip = localStorage.getItem('landing:skip') === 'true';
-        var last = parseInt(localStorage.getItem('landing:lastSeen'), 10) || 0;
-        var week = 1000 * 60 * 60 * 24 * 7;
-        if (!skip && Date.now() - last > week) {
-          location.href = 'landing.html';
-        }
-      } catch (e) {}
-    })();
-  </script>
   <script>window.APP_VERSION = '1.0.0';</script>
 </head>
 <body>
+<div id="intro" hidden>
+  <canvas id="intro-canvas"></canvas>
+
+  <div class="intro-ui">
+    <h1>Glitch Registry</h1>
+    <p>Подёргай реальность. Сначала красиво — потом глубоко.</p>
+    <button id="intro-enter" class="btn">Войти в реестр</button>
+  </div>
+
+  <div class="intro-controls">
+    <label><input id="intro-always-skip" type="checkbox"> Всегда пропускать</label>
+    <button id="intro-mute" class="btn" data-muted>Mute</button>
+    <button id="intro-skip" class="btn">Skip intro</button>
+  </div>
+</div>
 <nav>
   <button id="sidebar-toggle" type="button" aria-controls="sidebar">≡ Список</button>
   <a href="#/glitch/observer-problem">Реестр</a>
@@ -60,6 +57,7 @@
 <script src="assets/js/progress.js"></script>
 <script src="assets/js/screen-shader.js"></script>
 <script src="assets/js/night-mode.js"></script>
+<script src="assets/js/intro.js" defer></script>
 <script src="assets/js/router.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {

--- a/styles.css
+++ b/styles.css
@@ -934,3 +934,12 @@ input, select {
 .map-wrap{height:calc(100vh - 140px);margin:0 auto;max-width:1080px}
 .map-toolbar{display:flex;gap:8px;align-items:center;margin:8px 0 12px}
 .map-tip{position:fixed;pointer-events:none;padding:8px 10px;border-radius:8px;border:1px solid rgba(255,255,255,.15);background:rgba(0,0,0,.8)}
+
+#intro{position:fixed;inset:0;z-index:9999;display:grid;place-items:center;background:#000}
+#intro[hidden]{display:none}
+#intro-canvas{position:absolute;inset:0;width:100%;height:100%}
+.intro-ui{position:relative;text-align:center;padding:24px 28px}
+.intro-ui h1{margin:0 0 8px}
+.intro-controls{position:fixed;top:12px;right:12px;display:flex;gap:8px;align-items:center}
+.intro-controls .btn{padding:6px 10px}
+@media (prefers-reduced-motion: reduce){ #intro-canvas{display:none} }


### PR DESCRIPTION
## Summary
- add interactive intro overlay with canvas graphics and audio controls
- style and hook intro into hub and router
- disable router's auto-redirect so intro can manage navigation

## Testing
- `npm test`
- `npm run lint:html`
- `npm run lint:md`
- `npm run check:manifest`
- `npm run check:cards`
- `npm run check:links` *(fails: external links in existing markdown files)*


------
https://chatgpt.com/codex/tasks/task_e_689734c17db483219d08b874a942ddc0