### PR TITLE
feat: add animated intro screen

### DIFF
--- a/assets/js/intro.js
+++ b/assets/js/intro.js
@@ -1,63 +1,77 @@
 (() => {
   const LS = {
-    get k() { return { skip:'intro:alwaysSkip', seen:'intro:lastSeen', muted:'intro:muted' } }
+    get k() { return { skip: 'intro:alwaysSkip', seen: 'intro:lastSeen', mute: 'intro:mute' }; }
   };
-  let ctx, audio, started=false, muted=false, rafId;
+  let ctx, audio, started = false, muted = false, rafId;
+  const bursts = [];
+  let motion = 0;
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  function initAudio(){
+  function initAudio() {
     if (audio) return;
     try {
-      const AC = window.AudioContext||window.webkitAudioContext;
+      const AC = window.AudioContext || window.webkitAudioContext;
       audio = new AC();
-      const o1 = audio.createOscillator(), o2 = audio.createOscillator();
-      const g1 = audio.createGain(), g2 = audio.createGain();
-      const filt = audio.createBiquadFilter();
-      const fb = audio.createDelay(); const fbGain = audio.createGain();
-      o1.type='sine'; o2.type='triangle';
-      o1.frequency.value=110; o2.frequency.value=220;
-      g1.gain.value=g2.gain.value=0.03;
-      filt.type='lowpass'; filt.frequency.value=1200;
-      fb.delayTime.value=0.25; fbGain.gain.value=0.2;
-
-      o1.connect(g1).connect(filt);
-      o2.connect(g2).connect(filt);
-      filt.connect(audio.destination);
-      filt.connect(fb).connect(fbGain).connect(filt);
-
-      o1.start(); o2.start();
-    } catch {}
+      const osc = audio.createOscillator();
+      const gain = audio.createGain();
+      osc.type = 'sawtooth';
+      osc.frequency.value = 110;
+      gain.gain.value = 0.02;
+      osc.connect(gain).connect(audio.destination);
+      osc.start();
+    } catch (e) {}
   }
 
-  function draw(ts){
-    const c=document.getElementById('intro-canvas');
-    if(!c) return;
-    if(!ctx){ c.width=innerWidth; c.height=innerHeight; ctx=c.getContext('2d'); }
-    const w=c.width=innerWidth, h=c.height=innerHeight;
-    ctx.fillStyle='rgba(0,0,0,0.3)'; ctx.fillRect(0,0,w,h);
-    for(let i=0;i<180;i++){
-      const x=(Math.sin(i*13.37+ts*0.0007)+1)/2*w;
-      const y=(Math.cos(i*9.91 +ts*0.0004)+1)/2*h;
-      const r=(Math.sin(i+ts*0.002)+1)*1.2+0.3;
-      ctx.fillStyle=`hsl(${(i*7+ts*0.02)%360} 80% 60% / .6)`;
-      ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+  function spawnBurst(x, y) {
+    bursts.push({ x, y, r: 0 });
+  }
+
+  function draw(ts) {
+    const c = document.getElementById('intro-canvas');
+    if (!c) return;
+    if (!ctx) { c.width = innerWidth; c.height = innerHeight; ctx = c.getContext('2d'); }
+    const w = c.width = innerWidth, h = c.height = innerHeight;
+    ctx.fillStyle = 'rgba(0,0,0,0.2)';
+    ctx.fillRect(0, 0, w, h);
+
+    const speed = prefersReduced ? (0.3 + 0.3 * Math.sin(ts * 0.001)) : Math.min(1, motion / 40);
+    if (!prefersReduced) motion *= 0.9;
+
+    const count = 80 + speed * 160;
+    for (let i = 0; i < count; i++) {
+      const x = Math.random() * w;
+      const y = Math.random() * h;
+      const s = 1 + speed * 5;
+      ctx.fillStyle = `hsl(${Math.random() * 360} 90% 60% / ${0.2 + speed * 0.5})`;
+      ctx.fillRect(x, y, s, s);
     }
-    rafId=requestAnimationFrame(draw);
+
+    for (let i = bursts.length - 1; i >= 0; i--) {
+      const b = bursts[i];
+      b.r += 2 + speed * 8;
+      if (b.r > 200) { bursts.splice(i, 1); continue; }
+      ctx.strokeStyle = `hsl(${(ts * 0.05 + b.r) % 360} 80% 70% / ${1 - b.r / 200})`;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(b.x - b.r / 2, b.y - b.r / 2, b.r, b.r);
+    }
+
+    rafId = requestAnimationFrame(draw);
   }
 
-  function prefetch(){
-    const s1=document.createElement('link');
-    s1.rel='prefetch'; s1.href='assets/js/router.js';
-    document.head.appendChild(s1);
-    const s2=document.createElement('link');
-    s2.rel='prefetch'; s2.href='content/glitches.json';
-    document.head.appendChild(s2);
+  function prefetch() {
+    ['router.js', 'md.js', 'widgets.js'].forEach(src => {
+      const l = document.createElement('link');
+      l.rel = 'prefetch';
+      l.href = 'assets/js/' + src;
+      document.head.appendChild(l);
+    });
   }
 
-  function show(force=false){
-    const seen=+localStorage.getItem(LS.k.seen)||0;
-    const skip=localStorage.getItem(LS.k.skip)==='1';
-    const week=7*24*3600*1000;
-    if (!force && skip && Date.now()-seen<week){
+  function show(force = false) {
+    const seen = +localStorage.getItem(LS.k.seen) || 0;
+    const skip = localStorage.getItem(LS.k.skip) === '1';
+    const week = 7 * 24 * 3600 * 1000;
+    if (!force && (skip || Date.now() - seen < week)) {
       location.hash = location.hash || '#/overview';
       return;
     }
@@ -66,43 +80,70 @@
     requestIdleCallback?.(prefetch);
   }
 
-  function hideToHub(){
+  function hideToHub() {
     localStorage.setItem(LS.k.seen, Date.now().toString());
     cancelAnimationFrame(rafId);
-    document.getElementById('intro')?.setAttribute('hidden','');
-    location.hash='#/overview';
+    document.getElementById('intro')?.setAttribute('hidden', '');
+    location.hash = '#/overview';
   }
 
-  function bind(){
-    const enter=document.getElementById('intro-enter');
-    const skip=document.getElementById('intro-skip');
-    const always=document.getElementById('intro-always-skip');
-    const mute=document.getElementById('intro-mute');
+  function bind() {
+    const introEl = document.getElementById('intro');
+    const enter = document.getElementById('intro-enter');
+    const always = document.getElementById('intro-always-skip');
+    const mute = document.getElementById('intro-mute');
+    const canvas = document.getElementById('intro-canvas');
 
-    const gesture=()=>{ if(!started){ initAudio(); started=true; } };
-    ['click','pointerdown','keydown','touchstart'].forEach(ev=>{
-      document.addEventListener(ev,gesture,{once:true,passive:true});
+    const gesture = () => { if (!started) { initAudio(); started = true; if (muted && audio) audio.suspend().catch(() => {}); } };
+    ['click', 'pointerdown', 'touchstart', 'keydown'].forEach(ev => {
+      document.addEventListener(ev, gesture, { once: true, passive: true });
     });
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && !introEl.hasAttribute('hidden')) hideToHub();
+    });
+
+    canvas?.addEventListener('click', e => {
+      const r = canvas.getBoundingClientRect();
+      spawnBurst(e.clientX - r.left, e.clientY - r.top);
+    });
+
+    if (!prefersReduced) {
+      let lastX, lastY;
+      window.addEventListener('mousemove', e => {
+        if (lastX !== undefined) {
+          const dx = e.clientX - lastX, dy = e.clientY - lastY;
+          motion = Math.min(100, motion + Math.sqrt(dx * dx + dy * dy));
+        }
+        lastX = e.clientX; lastY = e.clientY;
+      });
+    }
 
     enter?.addEventListener('click', hideToHub);
-    skip?.addEventListener('click', hideToHub);
-    always?.addEventListener('change', e=>{
-      localStorage.setItem(LS.k.skip, e.target.checked?'1':'');
-      hideToHub();
-    });
-    mute?.addEventListener('click', ()=>{
-      muted=!muted; localStorage.setItem(LS.k.muted, muted?'1':'');
-      mute.toggleAttribute('data-muted', muted);
-      if (audio) (muted? audio.suspend(): audio.resume()).catch(()=>{});
+
+    always?.addEventListener('change', e => {
+      localStorage.setItem(LS.k.skip, e.target.checked ? '1' : '');
     });
 
-    if (localStorage.getItem(LS.k.muted)==='1') mute?.setAttribute('data-muted','');
+    mute?.addEventListener('click', () => {
+      muted = !muted;
+      localStorage.setItem(LS.k.mute, muted ? '1' : '');
+      mute.textContent = muted ? '🔇' : '🔊';
+      mute.toggleAttribute('data-muted', muted);
+      if (audio) (muted ? audio.suspend() : audio.resume()).catch(() => {});
+    });
+
+    muted = localStorage.getItem(LS.k.mute) === '1';
+    if (muted) mute?.setAttribute('data-muted', '');
+    mute && (mute.textContent = muted ? '🔇' : '🔊');
+    if (always && localStorage.getItem(LS.k.skip) === '1') always.checked = true;
   }
 
   window.intro = { show, hideToHub };
-  window.addEventListener('DOMContentLoaded', ()=>{
+  window.addEventListener('DOMContentLoaded', () => {
     bind();
-    const url=new URL(location.href);
-    if (url.searchParams.get('skip')==='0') show(true); else show(false);
+    const url = new URL(location.href);
+    if (url.searchParams.get('skip') === '0') show(true); else show(false);
   });
 })();
+

--- a/index.html
+++ b/index.html
@@ -14,14 +14,10 @@
   <div class="intro-ui">
     <h1>Glitch Registry</h1>
     <p>Подёргай реальность. Сначала красиво — потом глубоко.</p>
-    <button id="intro-enter" class="btn">Войти в реестр</button>
+    <label><input id="intro-always-skip" type="checkbox"> Пропускать всегда</label>
+    <button id="intro-enter" class="btn" aria-label="Войти в реестр">Войти в реестр</button>
   </div>
-
-  <div class="intro-controls">
-    <label><input id="intro-always-skip" type="checkbox"> Всегда пропускать</label>
-    <button id="intro-mute" class="btn" data-muted>Mute</button>
-    <button id="intro-skip" class="btn">Skip intro</button>
-  </div>
+  <button id="intro-mute" class="btn" aria-label="Звук вкл/выкл" data-muted>🔊</button>
 </div>
 <nav>
   <button id="sidebar-toggle" type="button" aria-controls="sidebar">≡ Список</button>
@@ -58,7 +54,7 @@
 <script src="assets/js/screen-shader.js"></script>
 <script src="assets/js/night-mode.js"></script>
 <script src="assets/js/intro.js" defer></script>
-<script src="assets/js/router.js"></script>
+<script src="assets/js/router.js" defer></script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
     window.initScreenShader && window.initScreenShader();

--- a/styles.css
+++ b/styles.css
@@ -935,11 +935,11 @@ input, select {
 .map-toolbar{display:flex;gap:8px;align-items:center;margin:8px 0 12px}
 .map-tip{position:fixed;pointer-events:none;padding:8px 10px;border-radius:8px;border:1px solid rgba(255,255,255,.15);background:rgba(0,0,0,.8)}
 
-#intro{position:fixed;inset:0;z-index:9999;display:grid;place-items:center;background:#000}
+#intro{position:fixed;inset:0;z-index:9999;display:grid;place-items:center;background:#000;overflow:hidden}
 #intro[hidden]{display:none}
 #intro-canvas{position:absolute;inset:0;width:100%;height:100%}
 .intro-ui{position:relative;text-align:center;padding:24px 28px}
 .intro-ui h1{margin:0 0 8px}
-.intro-controls{position:fixed;top:12px;right:12px;display:flex;gap:8px;align-items:center}
-.intro-controls .btn{padding:6px 10px}
-@media (prefers-reduced-motion: reduce){ #intro-canvas{display:none} }
+#intro-mute{position:fixed;top:12px;right:12px;padding:6px 10px}
+#intro button:focus-visible,#intro label:focus-within{outline:2px solid #fff;outline-offset:2px}
+@media (prefers-reduced-motion: reduce){ #intro-canvas{opacity:.4} }


### PR DESCRIPTION
## Summary
- implement fullscreen intro overlay with glitchy canvas and ambient audio
- add localStorage preferences for skipping and muting with 7-day TTL
- style intro and wire up routing to show hub after entry

## Testing
- `npm run lint:html`
- `npm run lint:md`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973d3e209c8321a93f8cce95a367c7