### PR TITLE
Card loader & map fallback fixes

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -1,4 +1,8 @@
 (() => {
+  if(!window.d3){
+    const t = document.querySelector('#content') || document.body;
+    t.innerHTML = '<div class="callout warn">Карта недоступна. D3 не загружен.</div>';
+  }
   const catSlugMap = {
     'Квант': 'quant',
     'Время': 'time',
@@ -17,13 +21,14 @@
     'Логика': '#ffd7a8',
     'Наблюдатель': '#b0ffc6'
   };
+  const manifestURL = window.repoURL ? window.repoURL('content/glitches.json') : 'content/glitches.json';
 
   window.renderMindMapFallback = async function(){
     const container = document.getElementById('content');
     if (!container) return;
     container.innerHTML = '';
     let manifest = [];
-    try { manifest = await fetch('content/glitches.json').then(r => r.json()); } catch(e){}
+    try { manifest = await fetch(manifestURL).then(r => r.json()); } catch(e){}
     const cats = Array.from(new Set(manifest.map(g => g.category)));
     let html = '<ul>';
     cats.forEach(c => {
@@ -42,7 +47,7 @@
 
     let manifest = [];
     try {
-      manifest = await fetch('content/glitches.json').then(r => r.json());
+      manifest = await fetch(manifestURL).then(r => r.json());
     } catch (e) {}
 
     const toolbar = document.createElement('div');

--- a/assets/js/scene-frame.js
+++ b/assets/js/scene-frame.js
@@ -5,10 +5,10 @@
     var nodes = Array.from(container.childNodes);
     container.innerHTML = '
       <div class="head"><h1 class="title"></h1><span class="chip cat"></span><div class="tags"></div></div>
-      <section class="scene-wrap">
-        <canvas id="scene-bg"></canvas>
+      <div class="scene-root">
+        <canvas id="scene-bg" class="scene-bg"></canvas>
         <div class="scene-content"></div>
-      </section>';
+      </div>';
     var head = container.querySelector('.head');
     head.querySelector('.title').textContent = meta.title || '';
     var catEl = head.querySelector('.chip.cat');
@@ -31,10 +31,10 @@
       p.textContent = meta.intro || 'эта сцена ещё в разработке';
       content.appendChild(p);
     }
-    var wrap = container.querySelector('.scene-wrap');
-    var bg = container.querySelector('#scene-bg');
+    var root = container.querySelector('.scene-root');
+    var bg = container.querySelector('.scene-bg');
     function fit(){
-      var r = wrap.getBoundingClientRect();
+      var r = root.getBoundingClientRect();
       bg.width = r.width;
       bg.height = r.height;
     }

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,8 @@
     box-sizing: border-box;
 }
 
+html,body{height:100%}
+
 body{
     font-family: 'Orbitron', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background: var(--brand-bg);
@@ -820,9 +822,9 @@ input, select {
 
 .card-wrap{max-width:980px;margin:0 auto;padding:16px;min-height:calc(100vh - 160px);}
 /* контейнер сцены на всю высоту вьюпорта */
-.scene-wrap{position:relative;min-height:calc(100vh - 120px)}
-.scene-wrap>canvas{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
-.scene-content{position:relative;padding:16px}
+.scene-root{position:relative;min-height:100vh;}
+.scene-bg{position:absolute;inset:0;z-index:0}
+.scene-content{position:relative;z-index:1;max-width:1080px;margin:0 auto;padding:16px}
 
 .md-body { max-width:100%; margin:0 auto; padding:16px 20px; line-height:1.65; color:inherit; }
 .md-body h2, .md-body h3 { margin:1.2em 0 .4em; font-size:clamp(18px,2vw,22px); scroll-margin-top:84px; }


### PR DESCRIPTION
## Summary
- ensure router fetches cards/scenes relative to repo root and handles fetch errors
- render scenes full-bleed with new scene frame structure
- load mind map lazily with offline fallback

## Testing
- `node --check assets/js/router.js`
- `npm run doctor:manifest -- --write --stubs`
- `npm run lint:md`
- `npm run lint:html`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b46e704c832185302f56159cd6ed