### PR TITLE
fix: streamline progress and map loading

### DIFF
--- a/assets/js/progress.js
+++ b/assets/js/progress.js
@@ -2,132 +2,92 @@ const KEY = 'glitch:progress';
 const LAST_KEY = 'glitch:lastVisited';
 const QUIZ_PREFIX = 'gr:quiz:';
 
-function getProgress() {
-  try {
+function getProgress(){
+  try{
     return JSON.parse(localStorage.getItem(KEY)) || [];
-  } catch (e) {
+  }catch(e){
     return [];
   }
 }
 
-function saveProgress(list) {
-  localStorage.setItem(KEY, JSON.stringify(list));
+function saveProgress(list){
+  try{ localStorage.setItem(KEY, JSON.stringify(list)); }catch(e){}
 }
 
-function markDone(slug) {
-  const list = new Set(getProgress());
+function markDone(slug){
+  var list = new Set(getProgress());
   list.add(slug);
   saveProgress(Array.from(list));
 }
 
-function isDone(slug) {
+function isDone(slug){
   return getProgress().includes(slug);
 }
 
-function setLastVisited(data) {
-  try {
-    localStorage.setItem(LAST_KEY, JSON.stringify(data));
-  } catch (e) {}
+function setLastVisited(data){
+  try{ localStorage.setItem(LAST_KEY, JSON.stringify(data)); }catch(e){}
 }
 
-function getLastVisited() {
-  try {
-    return JSON.parse(localStorage.getItem(LAST_KEY));
-  } catch (e) {
-    return null;
-  }
+function getLastVisited(){
+  try{ return JSON.parse(localStorage.getItem(LAST_KEY)); }catch(e){ return null; }
 }
 
-function resetProgress() {
+function resetProgress(){
   localStorage.removeItem(KEY);
   localStorage.removeItem(LAST_KEY);
-  try {
+  try{
     var del = [];
-    for (var i = 0; i < localStorage.length; i++) {
+    for (var i=0;i<localStorage.length;i++){
       var k = localStorage.key(i);
-      if (k && k.indexOf(QUIZ_PREFIX) === 0) del.push(k);
+      if (k && k.indexOf(QUIZ_PREFIX)===0) del.push(k);
     }
-    del.forEach(function (k) { localStorage.removeItem(k); });
-  } catch (e) {}
+    del.forEach(function(k){ localStorage.removeItem(k); });
+  }catch(e){}
   quizCache = null;
 }
 
-function quizKey(slug, id) {
-  return QUIZ_PREFIX + slug + ':' + id;
-}
+function quizKey(slug,id){ return QUIZ_PREFIX+slug+':'+id; }
 
-function setQuizPassed(slug, id) {
+function setQuizPassed(slug,id){
   if (!slug || !id) return;
-  try { localStorage.setItem(quizKey(slug, id), '1'); } catch (e) {}
+  try{ localStorage.setItem(quizKey(slug,id),'1'); }catch(e){}
   quizCache = null;
 }
 
-function isQuizPassed(slug, id) {
+function isQuizPassed(slug,id){
   if (!slug || !id) return false;
-  try { return localStorage.getItem(quizKey(slug, id)) === '1'; } catch (e) { return false; }
+  try{ return localStorage.getItem(quizKey(slug,id))==='1'; }catch(e){ return false; }
 }
-
-var catSlugMap = {
-  'Квант': 'quant',
-  'Время': 'time',
-  'Космос': 'cosmos',
-  'Идентичность': 'id',
-  'Информация': 'info',
-  'Логика': 'logic',
-  'Наблюдатель': 'observer'
-};
 
 var quizCache = null;
 
-async function getQuizStats() {
+async function getQuizStats(){
   if (quizCache) return quizCache;
-  var res = { total: 0, passed: 0, byCategory: {}, bySlug: {} };
-  try {
-    var passedMap = {};
-    for (var i = 0; i < localStorage.length; i++) {
+  var res = { total:0, passed:0, bySlug:{} };
+  try{
+    for (var i=0;i<localStorage.length;i++){
       var k = localStorage.key(i);
-      if (k && k.indexOf(QUIZ_PREFIX) === 0) {
+      if (k && k.indexOf(QUIZ_PREFIX)===0){
         var parts = k.split(':');
         var slug = parts[2];
-        if (!passedMap[slug]) passedMap[slug] = new Set();
-        passedMap[slug].add(parts[3]);
+        res.total++;
+        res.passed++;
+        if (!res.bySlug[slug]) res.bySlug[slug] = { t:0, p:0 };
+        res.bySlug[slug].t++;
+        res.bySlug[slug].p++;
       }
     }
-    var manifest = (window.repoPaths && window.repoPaths.getManifest ? window.repoPaths.getManifest() : []);
-    Object.keys(passedMap).forEach(function (slug) {
-      var count = passedMap[slug].size;
-      res.total += count;
-      res.passed += count;
-      var item = manifest.find ? manifest.find(function (i) { return i.slug === slug; }) : null;
-      var cat = item ? (catSlugMap[item.category] || 'other') : 'other';
-      if (!res.byCategory[cat]) res.byCategory[cat] = { t: 0, p: 0 };
-      res.byCategory[cat].t += count;
-      res.byCategory[cat].p += count;
-      res.bySlug[slug] = { t: count, p: count };
-    });
-  } catch (e) {}
+  }catch(e){}
   quizCache = res;
   return res;
 }
 
-async function getStats() {
+function getStats(){
   var progress = getProgress();
-  var res = { doneCount: progress.length, byCategory: {} };
-  try {
-    var manifest = (window.repoPaths && window.repoPaths.getManifest ? window.repoPaths.getManifest() : []);
-    if (!manifest.length && window.repoPaths && window.repoPaths.fetchText) {
-      manifest = JSON.parse(await window.repoPaths.fetchText('content/glitches.json'));
-    }
-    manifest.forEach(function (g) {
-      var slug = catSlugMap[g.category] || 'other';
-      if (!res.byCategory[slug]) res.byCategory[slug] = 0;
-      if (progress.includes(g.slug)) res.byCategory[slug] += 1;
-    });
-  } catch (e) {}
-  return res;
+  return { doneCount: progress.length, byCategory: {} };
 }
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined'){
   window.markDone = markDone;
   window.isDone = isDone;
   window.getProgress = getProgress;
@@ -152,6 +112,6 @@ if (typeof window !== 'undefined') {
   };
 }
 
-if (typeof module !== 'undefined') {
+if (typeof module !== 'undefined'){
   module.exports = { markDone, isDone, getProgress, setLastVisited, getLastVisited, resetProgress, getStats, setQuizPassed, isQuizPassed, getQuizStats };
 }

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -176,22 +176,26 @@
     });
   }
 
+  
   async function renderMapRoute(){
     try {
-      if (!window.renderMindMap) {
-        if (!window.d3) await loadScript('https://cdn.jsdelivr.net/npm/d3-force@3/dist/d3-force.min.js');
-        await loadScript('assets/js/map.js');
-      }
+      if (!window.d3) await loadScript('https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js');
+      if (!window.renderMindMap) await loadScript('assets/js/map.js');
       if (window.renderMindMap) {
         window.renderMindMap();
-      } else if (window.renderMindMapFallback) {
-        window.renderMindMapFallback();
+      } else {
+        throw new Error('renderMindMap missing');
       }
     } catch (e) {
       console.warn('[map] offline/fallback:', e);
       try {
         if (!window.renderMindMapFallback) await loadScript('assets/js/map.js');
-        window.renderMindMapFallback?.();
+        if (window.renderMindMapFallback) {
+          window.renderMindMapFallback();
+        } else {
+          var t = document.querySelector('#content') || document.body;
+          t.innerHTML = '<div class="callout warn">Карта недоступна. Проверьте сеть.</div>';
+        }
       } catch (e2) {
         var target = document.querySelector('#content') || document.body;
         target.innerHTML = '<div class="callout warn">Карта недоступна. Проверьте сеть.</div>';

--- a/assets/js/scene-frame.js
+++ b/assets/js/scene-frame.js
@@ -1,51 +1,52 @@
-(()=>{'use strict';
-  let resizeHandler = null;
-  function mountSceneFrame(slug, meta){
-    meta = meta || {};
-    const container = document.querySelector('#scene-root') || document.body;
-    const nodes = Array.from(container.childNodes);
-    container.innerHTML = '<div class="head"><h1 class="title"></h1><span class="chip cat"></span><div class="tags"></div></div>' +
-      '<div class="scene-root"><canvas id="scene-bg" class="scene-bg"></canvas><div class="scene-content"></div></div>';
-    const head = container.querySelector('.head');
-    head.querySelector('.title').textContent = meta.title || '';
-    const catEl = head.querySelector('.chip.cat');
-    catEl.textContent = meta.category || '';
-    try {
-      const th = window.theme || window.THEME;
-      const fn = th.catColor || th.categoryColor;
-      if (fn) catEl.style.color = fn(meta.category);
-    } catch(e){}
-    const tagBox = head.querySelector('.tags');
-    (Array.isArray(meta.tags)?meta.tags:[]).forEach(function(t){
-      const s = document.createElement('span');
-      s.className = 'chip';
-      s.textContent = t;
-      tagBox.appendChild(s);
-    });
-    const content = container.querySelector('.scene-content');
-    nodes.forEach(function(n){ content.appendChild(n); });
-    if (!content.textContent.trim()){
-      const p = document.createElement('p');
-      p.textContent = meta.intro || 'эта сцена ещё в разработке';
-      content.appendChild(p);
-    }
-    const root = container.querySelector('.scene-root');
-    const bg = container.querySelector('.scene-bg');
-    function fit(){
-      const r = root.getBoundingClientRect();
-      bg.width = r.width;
-      bg.height = r.height;
-    }
-    resizeHandler = fit;
-    window.addEventListener('resize', fit, {passive:true});
-    fit();
-    try { window.widgets?.mountAll(container); } catch(e){ console.warn('[widgets]', e); }
+(function(){
+'use strict';
+var resizeHandler = null;
+function mount(slug, meta){
+  meta = meta || {};
+  var container = document.querySelector('#scene-root') || document.body;
+  var nodes = Array.from(container.childNodes);
+  container.innerHTML = '<div class="head"><h1 class="title"></h1><span class="chip cat"></span><div class="tags"></div></div>'+
+    '<div class="scene-root"><canvas id="scene-bg" class="scene-bg"></canvas><div class="scene-content"></div></div>';
+  var head = container.querySelector('.head');
+  head.querySelector('.title').textContent = meta.title || '';
+  var catEl = head.querySelector('.chip.cat');
+  catEl.textContent = meta.category || '';
+  try{
+    var th = window.theme || window.THEME;
+    var fn = th.catColor || th.categoryColor;
+    if (fn) catEl.style.color = fn(meta.category);
+  }catch(e){}
+  var tagBox = head.querySelector('.tags');
+  (Array.isArray(meta.tags)?meta.tags:[]).forEach(function(t){
+    var s = document.createElement('span');
+    s.className = 'chip';
+    s.textContent = t;
+    tagBox.appendChild(s);
+  });
+  var content = container.querySelector('.scene-content');
+  nodes.forEach(function(n){ content.appendChild(n); });
+  if (!content.textContent.trim()){
+    var p = document.createElement('p');
+    p.textContent = meta.intro || 'scene in progress';
+    content.appendChild(p);
   }
-  function unmountSceneFrame(){
-    if (resizeHandler) {
-      window.removeEventListener('resize', resizeHandler, {passive:true});
-      resizeHandler = null;
-    }
+  var root = container.querySelector('.scene-root');
+  var bg = container.querySelector('.scene-bg');
+  function fit(){
+    var r = root.getBoundingClientRect();
+    bg.width = r.width;
+    bg.height = r.height;
   }
-  window.SceneFrame = { mount: mountSceneFrame, unmount: unmountSceneFrame };
+  resizeHandler = fit;
+  window.addEventListener('resize', fit, {passive:true});
+  fit();
+  try{ if (window.widgets && window.widgets.mountAll) window.widgets.mountAll(container); }catch(e){ console.warn('[widgets]', e); }
+}
+function unmount(){
+  if (resizeHandler){
+    window.removeEventListener('resize', resizeHandler, {passive:true});
+    resizeHandler = null;
+  }
+}
+window.SceneFrame = { mount: mount, unmount: unmount };
 })();

--- a/index.html
+++ b/index.html
@@ -52,15 +52,15 @@
 <script src="assets/js/widgets.js"></script>
 <script src="assets/js/quiz.js"></script>
 <script src="assets/js/quest.js"></script>
-<script src="assets/js/md.js"></script>
-<script src="assets/js/paths.js"></script>
-<script src="assets/js/progress.js"></script>
-<script src="assets/js/scene-frame.js"></script>
-<script src="assets/js/screen-shader.js"></script>
-<script src="assets/js/night-mode.js"></script>
-<script src="assets/js/audio.js"></script>
-<script src="assets/js/intro.js" defer></script>
-<script src="assets/js/router.js" defer></script>
+  <script src="assets/js/screen-shader.js"></script>
+  <script src="assets/js/night-mode.js"></script>
+  <script src="assets/js/audio.js"></script>
+  <script src="assets/js/paths.js"></script>
+  <script src="assets/js/progress.js"></script>
+  <script src="assets/js/md.js"></script>
+  <script src="assets/js/scene-frame.js"></script>
+  <script src="assets/js/intro.js" defer></script>
+  <script src="assets/js/router.js" defer></script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
     window.initScreenShader?.();


### PR DESCRIPTION
## Summary
- refactor progress tracker to only use localStorage
- serve SceneFrame via strict IIFE without module exports
- lazy-load full d3.js for map route with graceful fallback and reorder core scripts

## Testing
- `node --check assets/js/scene-frame.js`
- `node --check assets/js/router.js`
- `npm run lint:md`
- `npm run lint:html`
- `npm run doctor:manifest -- --write --stubs`
- `npm run check:manifest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d75d9fe88321b2196a98a985ba3f